### PR TITLE
Refactor to meet standardised Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ See the [examples/](examples/) folder.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.24.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.24.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
 
 ## Modules
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -4,6 +4,6 @@ provider "aws" {
 }
 
 module "template" {
-  source = "../"
+  source      = "../"
   eks_cluster = "test"
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">=4.24.0"
     }
   }
   required_version = ">= 0.14"

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "efs_doc" {
     condition {
       test     = "StringLike"
       variable = "aws:RequestTag/efs.csi.aws.com/cluster"
-      values = ["true"]
+      values   = ["true"]
     }
   }
 
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "efs_doc" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
-      values = ["true"]
+      values   = ["true"]
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,16 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-    }
-    kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/aws"
+      version = ">=4.24.0"
     }
     helm = {
       source = "hashicorp/helm"
-    }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
+      version = ">=2.6.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR:

- runs terraform fmt
- adds minimum provider versions
- removes the unused `kubernetes` and `kubectl` providers